### PR TITLE
Remove irrevelant words

### DIFF
--- a/lib/genius_lyrics.dart
+++ b/lib/genius_lyrics.dart
@@ -227,8 +227,13 @@ class Genius {
 
     BeautifulSoup bs = BeautifulSoup(getResponse.replaceAll('<br/>', '\n'));
 
-    return bs.find("div", class_: "Lyrics__Root")?.getText() ??
-        bs.find("div", class_: "lyrics")?.getText().trim();
+    String excludedFooter =
+        bs.find("div", class_: "Lyrics__Footer")?.getText().trim() ?? '';
+
+    return (bs.find("div", class_: "Lyrics__Root")?.getText().trim() ??
+        bs.find("div", class_: "lyrics")?.getText().trim())
+        ?.replaceAll(RegExp('You might also like[0-9]+Embed'), '')
+        .replaceAll(excludedFooter, '');
   }
 
   /// Searches for a specific song and gets its lyrics returning [Song] in case it's successful and `null` otherwise .


### PR DESCRIPTION
This is the fix for https://github.com/hbtalha/genius_lyrics/issues/1
Since the library was collecting text from the Footer div so there were some irrelevant words such as "You might also likeXEmbed", "XEmbed".
This fix will exclude those text out of parsed lyrics.

Note: I closed the previous PR because of messy commit order.