### PR TITLE
fix: lyrics return empty 

### DIFF
--- a/lib/src/genius.dart
+++ b/lib/src/genius.dart
@@ -260,7 +260,7 @@ class Genius {
     BeautifulSoup bs = BeautifulSoup(responseBody.replaceAll('<br/>', '\n'));
 
     return bs
-        .findAll('div', class_: 'Lyrics__Container')
+        .findAll('div', attrs: {"data-lyrics-container": "true"})
         .map((e) => e.getText().trim())
         .join('\n');
   }


### PR DESCRIPTION
This pull request includes a change in the `Genius` class within the `lib/src/genius.dart` file to improve the way lyrics are extracted from the HTML response. The change modifies the method used to find the relevant HTML elements containing the lyrics.

* [`lib/src/genius.dart`](diffhunk://#diff-e5f0195a79bde9ab4a07fe87ff2c84665486866278764f5edcbfab40a8fe9e19L263-R263): Updated the `findAll` method to search for `div` elements with the attribute `data-lyrics-container` set to `true` instead of using the class `Lyrics__Container`.
* close #29 